### PR TITLE
Changed save function to touch session updated field

### DIFF
--- a/Sources/MySQLSessions.swift
+++ b/Sources/MySQLSessions.swift
@@ -43,11 +43,11 @@ public struct MySQLSessions {
 		// perform UPDATE
 		let stmt = "UPDATE \(MySQLSessionConnector.table) SET userid = ?, updated = ?, idle = ?, data = ? WHERE token = ?"
 		exec(stmt, params: [
-			session.userid,
-			session.updated,
-			session.idle,
-			session.tojson(),
-			session.token
+			s.userid,
+			s.updated,
+			s.idle,
+			s.tojson(),
+			s.token
 			])
 	}
 


### PR DESCRIPTION
In the changed code, the update statement was running with parameters from "session".  touch() is called on "s", so the updated timestamp wasn't being set in the database, causing in-use sessions to expire.